### PR TITLE
chore: version bump for studio, hyperon-runtime and bundle-h2-demo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,11 +53,11 @@ npm install npm@latest -g
 Make sure that both commands ```mvn``` and ```npm``` are accessible through system path. If not, add them.
 In file ```hyperon-demo-app.properties``` set ```hyperon.database.url``` to point Hyperon Studio H2 database file, e.g.:
 ```properties
-hyperon.database.url=jdbc:h2:/srv/hyperon-studio-1.6.50/database/hyperon.demo;AUTO_SERVER=TRUE;MVCC=TRUE;IFEXISTS=TRUE
+hyperon.database.url=jdbc:h2:/srv/hyperon-studio-1.6.50/database/hyperon.demo
 ```
 or on Windows
 ```properties
-hyperon.database.url=jdbc:h2:c:/hyperon-studio-1.6.50/database/hyperon.demo;AUTO_SERVER=TRUE;MVCC=TRUE;IFEXISTS=TRUE
+hyperon.database.url=jdbc:h2:c:/hyperon-studio-1.6.50/database/hyperon.demo
 ```
 
 ## Running
@@ -92,9 +92,9 @@ docker run -p 48080:48080 \
     -e hyperon.studio.instance-name=hyperon_docker \
     hyperonio/motor-demo
 ```
-
-OR application can be run with bundle-h2-demo and hyperon-studio images
-using docker-compose based on [docker-compose.yml](./docker-compose.yml). Simply run:
+## Running with Docker compose
+Application can be run with bundle-h2-demo and hyperon-studio images using docker-compose based on [docker-compose.yml](./docker-compose.
+yml)
 ```shell
 docker-compose up   
 # or (regarding to docker version)

--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ To update:
 npm install npm@latest -g
 ```
 
-#### Hyperon Studio 2.1.3
+#### Hyperon Studio 2.2.2
 1. Go to:  https://www.hyperon.io/docs/download
 2. download bundle, unpack it to the directory of your choice and run it as described [here](https://www.hyperon.io/tutorial/installing-hyperon-studio). 
 
@@ -53,11 +53,11 @@ npm install npm@latest -g
 Make sure that both commands ```mvn``` and ```npm``` are accessible through system path. If not, add them.
 In file ```hyperon-demo-app.properties``` set ```hyperon.database.url``` to point Hyperon Studio H2 database file, e.g.:
 ```properties
-hyperon.database.url=jdbc:h2:/srv/hyperon-studio-1.6.50/database/hyperon.demo
+hyperon.database.url=jdbc:h2:/hyperon-studio/database/hyperon.demo
 ```
 or on Windows
 ```properties
-hyperon.database.url=jdbc:h2:c:/hyperon-studio-1.6.50/database/hyperon.demo
+hyperon.database.url=jdbc:h2:c:/hyperon-studio/database/hyperon.demo
 ```
 
 ## Running

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 services:
   db:
     container_name: db
-    image: hyperonio/bundle-h2-demo:latest
+    image: hyperonio/bundle-h2-demo:2.0.2
     ports:
       - "8082:8082"
       - "9092:9092"
@@ -11,9 +11,9 @@ services:
 
   studio:
     container_name: studio
-    image: hyperonio/studio:2.1.3
+    image: hyperonio/studio:2.2.2
     environment:
-      - hyperon.database.url=jdbc:h2:tcp://db/hyperon.demo;AUTO_SERVER=TRUE;MVCC=TRUE;IFEXISTS=TRUE
+      - hyperon.database.url=jdbc:h2:tcp://db/hyperon.demo
       - hyperon.database.dialect=h2
       - hyperon.database.username=sa
       - hyperon.database.password=sa
@@ -27,9 +27,9 @@ services:
 
   runtime-rest:
     container_name: runtime-rest
-    image: hyperonio/runtime-rest:2.1.3
+    image: hyperonio/runtime-rest:2.2.2
     environment:
-      - hyperon.database.url=jdbc:h2:tcp://db/hyperon.demo;AUTO_SERVER=TRUE;MVCC=TRUE;IFEXISTS=TRUE
+      - hyperon.database.url=jdbc:h2:tcp://db/hyperon.demo
       - hyperon.database.dialect=h2
       - hyperon.database.username=sa
       - hyperon.database.password=sa
@@ -45,7 +45,7 @@ services:
     container_name: demo
     image: hyperonio/motor-demo:latest
     environment:
-      - HYPERON_DATABASE_URL=jdbc:h2:tcp://db/hyperon.demo;AUTO_SERVER=TRUE;MVCC=TRUE;IFEXISTS=TRUE
+      - HYPERON_DATABASE_URL=jdbc:h2:tcp://db/hyperon.demo
     ports:
       - "48080:48080"
     depends_on:

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>pl.decerto</groupId>
 	<artifactId>motor-insurance</artifactId>
-	<version>1.0-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 
 	<parent>
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>pl.decerto</groupId>
 			<artifactId>hyperon-runtime</artifactId>
-			<version>2.1.3</version>
+			<version>2.2.2</version>
 		</dependency>
 
 		<!-- Spring Framework -->


### PR DESCRIPTION
Change version of studio, runtime and h2. Version of demo move to 2.0-SNAPSHOT